### PR TITLE
Refactor

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -10,14 +10,13 @@ pub struct Config{
 }
 
 impl Config {
-    pub fn new(args: &[String]) -> Result<Self, &'static str> {
+    pub fn new(args: &[String]) -> Self {
         if args.len() < 3 {
-             Err("not enough arguments supplied to function!")
-        } else {
+             panic!("not enough arguments supplied, terminating program")
+        } 
             let path = args[1].clone();
             let root = args[2].clone();
-            Ok(Config { path, root })
-        }
+            Config { path, root }
     }
 
 
@@ -26,10 +25,10 @@ impl Config {
         let reader = BufReader::new(file);
     
         for(_index, line) in reader.lines().enumerate(){
-            let new_path = Path::new(&self.root).join(line?);
+            let new_path = Path::new(&self.root).join(line?);    
+            fs::create_dir_all(&new_path)?;
             println!("Created folder : {}", new_path.display());
-    
-            fs::create_dir_all(new_path)?;
+
         }
         Ok(())
     }

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -1,0 +1,37 @@
+use std::error::Error;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::fs;
+
+
+pub struct Config{
+    path : String,
+    root : String,
+}
+
+impl Config {
+    pub fn new(args: &[String]) -> Result<Self, &'static str> {
+        if args.len() < 3 {
+             Err("not enough arguments supplied to function!")
+        } else {
+            let path = args[1].clone();
+            let root = args[2].clone();
+            Ok(Config { path, root })
+        }
+    }
+
+
+    pub fn run(&self) -> Result<(), Box<dyn Error>>{
+        let file = fs::File::open(&self.path)?;
+        let reader = BufReader::new(file);
+    
+        for(_index, line) in reader.lines().enumerate(){
+            let new_path = Path::new(&self.root).join(line?);
+            println!("Created folder : {}", new_path.display());
+    
+            fs::create_dir_all(new_path)?;
+        }
+        Ok(())
+    }
+    
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,9 +36,9 @@ fn run(config : Config) -> Result<(), Box<dyn Error>>{
 }
 
 fn main() {
-    let args : Vec<String> = env::args().collect();
+    let args = env::args().collect::<Vec<String>>();
 
-    let config : Config = Config::new(&args).unwrap_or_else(|err| {
+    let config = Config::new(&args).unwrap_or_else(|err| {
         println!("Problem parsing {}", err);
         process::exit(1);
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,39 +1,10 @@
+
+pub mod conf;
+
 use std::env;
-use std::fs;
 use std::process;
-use std::error::Error;
-use std::io::{BufRead, BufReader};
-use std::path::Path;
 
-
-struct Config{
-    path : String,
-    root : String,
-}
-
-impl Config {
-    fn new(args: &[String]) -> Result<Config, &'static str> {
-        if args.len() < 3 {
-            return Err("not enough arguments supplied to function!")
-        }
-        let path = args[1].clone();
-        let root = args[2].clone();
-        Ok(Config { path, root })
-    }
-}
-
-fn run(config : Config) -> Result<(), Box<dyn Error>>{
-    let file = fs::File::open(config.path)?;
-    let reader = BufReader::new(file);
-
-    for(_index, line) in reader.lines().enumerate(){
-        let new_path = Path::new(&config.root).join(line?);
-        println!("Created folder : {}", new_path.display());
-
-        fs::create_dir_all(new_path)?;
-    }
-    Ok(())
-}
+use crate::conf::Config;
 
 fn main() {
     let args = env::args().collect::<Vec<String>>();
@@ -43,7 +14,7 @@ fn main() {
         process::exit(1);
     });
 
-    if let Err(e) = run(config){
+    if let Err(e) = config.run(){
         println!("Application error : {}",e);
         process::exit(1);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,10 +9,7 @@ use crate::conf::Config;
 fn main() {
     let args = env::args().collect::<Vec<String>>();
 
-    let config = Config::new(&args).unwrap_or_else(|err| {
-        println!("Problem parsing {}", err);
-        process::exit(1);
-    });
+    let config = Config::new(&args);
 
     if let Err(e) = config.run(){
         println!("Application error : {}",e);


### PR DESCRIPTION
Tried  modularization  of Config in it's own mod, to better separate logic and imports. Used tubrofish notation `::<>`, and used self and Self whenever possible.